### PR TITLE
Fixed installer.lua behavior when initializing fLoc and fPath on Windows

### DIFF
--- a/lua/pineapple/installer.lua
+++ b/lua/pineapple/installer.lua
@@ -48,7 +48,7 @@ function M.getInstallFileName()
     local fPath = string.gsub(installFile, "%.", "/")
     local fLoc = ""
     if jit.os == "Windows" then
-        fLoc = os.getenv("USERPROFILE") .. "AppData\\Local\\nvim\\lua\\" .. fPath .. ".lua"
+        fLoc = os.getenv("USERPROFILE") .. "\\AppData\\Local\\nvim\\lua\\" .. fPath .. ".lua"
     else
         fLoc = os.getenv("HOME") .. "/.config/nvim/lua/" .. fPath .. ".lua"
     end
@@ -134,7 +134,7 @@ function M.setColorscheme(colorscheme)
     end
     local fPath = ""
     if jit.os == "Windows" then
-        fPath = os.getenv("USERPROFILE") .. "AppData\\Local\\nvim\\" .. colorSchemeFile
+        fPath = os.getenv("USERPROFILE") .. "\\AppData\\Local\\nvim\\" .. colorSchemeFile
     else
         fPath = os.getenv("HOME") .. "/.config/nvim/" .. colorSchemeFile
     end


### PR DESCRIPTION
When initializing `fLoc` and `fPath` on Windows, it was assumed that `%USERPROFILE%` ends with a backslash, which it does not. As a result, Windows users experienced issues where installing a new theme would lead to the following error:
```
Could not open file: C:\Users\someuserAppData\Local\...
```

**Therefore, the modifications I made on lines `51` and `137` now create the expected path.**

This fix has been tested on Neovim `0.9.5` and Windows 11. If `%USERPROFILE%` does end with a backslash on some PCs, it will not cause issues as both `//` and `/` are interpreted correctly on Windows.